### PR TITLE
Bugfix/#16798 redborder cep user does not exist

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -5,6 +5,7 @@ include RbCep::Helper
 
 action :add do
   begin
+    user = new_resource.user
     vault_nodes = new_resource.vault_nodes
     ips_nodes = new_resource.ips_nodes
     flow_nodes = new_resource.flow_nodes
@@ -25,6 +26,18 @@ action :add do
     dnf_package 'redborder-cep' do
       action :upgrade
       flush_cache[:before]
+    end
+
+    execute 'create_group' do
+      command "groupadd #{user}"
+      ignore_failure true
+      not_if "getent group #{user}"
+    end
+
+    execute 'create_user' do
+      command "/usr/sbin/useradd -g #{user} #{user}"
+      ignore_failure true
+      not_if "getent passwd #{user}"
     end
 
     directory '/etc/redborder-cep' do


### PR DESCRIPTION
## Related Issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/16798)

## Description / Motivation

The `provider/config.rb` currently fails to create the redborder-cep user in `/etc/passwd`.

## Detail

The updated code addresses this by ensuring the redborder-cep user and group are correctly configured. It first checks if the redborder-cep group exists; if not, it creates the group. Then, it creates the redborder-cep user and ensures both are properly listed in `/etc/passwd`. Additionally, a home directory for redborder-cep is created at `/home/redborder-cep`.

## Additional Information

The `create_group` section was introduced to prevent errors from occurring when attempting to create the user if the required group already exists. This improvement ensures smooth execution of the `/usr/sbin/useradd`command without interruptions due to pre-existing group configurations.